### PR TITLE
bugfix: Correct order of parameters in ReceiptItem

### DIFF
--- a/cpp/model/ReceiptItem.cpp
+++ b/cpp/model/ReceiptItem.cpp
@@ -1,6 +1,6 @@
 #include "ReceiptItem.h"
 
-ReceiptItem::ReceiptItem(const Product& product, double price, double totalPrice, double quantity)
+ReceiptItem::ReceiptItem(const Product& product, double quantity, double price, double totalPrice)
     : product(product), price(price), totalPrice(totalPrice), quantity(quantity) {}
 
 Product ReceiptItem::getProduct() const {

--- a/cpp/model/ReceiptItem.h
+++ b/cpp/model/ReceiptItem.h
@@ -6,8 +6,7 @@
 
 class ReceiptItem {
 public:
-    ReceiptItem(const Product& product, double price, double totalPrice, double quantity);
-
+    ReceiptItem(const Product& product, double quantity, double price, double totalPrice);
     Product getProduct() const;
 
     double getPrice() const;


### PR DESCRIPTION
This bug was not introduced on intention.