### PR TITLE
cpp/test-catch2: Bump Catch2 version

### DIFF
--- a/cpp/test-catch2/CMakeLists.txt
+++ b/cpp/test-catch2/CMakeLists.txt
@@ -6,7 +6,7 @@ set(SOURCE_FILES main.cpp sample_catch.cpp)
 FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG        v2.13.1)
+        GIT_TAG        v2.13.10)
 FetchContent_MakeAvailable(Catch2)
 
 # approvals


### PR DESCRIPTION
Add compatibility with recent `glibc` versions by bumping the minor
version of `Catch2` to the latest one.

Addresses #53.