### PR TITLE
cpp/CMakeLists.txt: Relax CMake version requirement

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20.2)
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 project(SupermarketReceipt VERSION 1.0
         LANGUAGES CXX)


### PR DESCRIPTION
Don't require what is not needed. This enables build in Ubuntu 20.04
containers.

Addresses #53.