### PR TITLE
Upgrade dependencies for Java version

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -35,7 +35,8 @@
         <dependency>
             <groupId>com.approvaltests</groupId>
             <artifactId>approvaltests</artifactId>
-            <version>24.2.0</version>
+            <version>24.12.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -46,8 +46,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <source>22</source>
-                    <target>22</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>22</source>
                     <target>22</target>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.jupiter.version>5.11.4</junit.jupiter.version>
     </properties>
 
 


### PR DESCRIPTION
Just a heads up, also:

- I upgraded the approval tests library, even though it isn't used (there are some unused imports though)
- The project is compiling for Java 22, which isn't supported now. I suppose it's not too big a deal, but I could either change it to 23 (the current latest), or 21 (current LTS) as you prefer.