### PR TITLE
Assignments at declaration

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,8 +45,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>22</source>
-                    <target>22</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/java/src/main/java/dojo/supermarket/ReceiptPrinter.java
+++ b/java/src/main/java/dojo/supermarket/ReceiptPrinter.java
@@ -74,7 +74,7 @@ public class ReceiptPrinter {
     }
 
     private static String presentQuantity(ReceiptItem item) {
-        return ProductUnit.Each.equals(item.getProduct().getUnit())
+        return ProductUnit.EACH.equals(item.getProduct().getUnit())
                 ? String.format("%x%s", (int)item.getQuantity(), item.getQuantityType())
                 : String.format(Locale.UK, "%.3f%s", item.getQuantity(), item.getQuantityType());
     }

--- a/java/src/main/java/dojo/supermarket/model/ProductUnit.java
+++ b/java/src/main/java/dojo/supermarket/model/ProductUnit.java
@@ -1,5 +1,5 @@
 package dojo.supermarket.model;
 
 public enum ProductUnit {
-    Kilo, Each
+    KILO, EACH
 }

--- a/java/src/test/java/dojo/supermarket/ReceiptPrinterTest.java
+++ b/java/src/test/java/dojo/supermarket/ReceiptPrinterTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 
 public class ReceiptPrinterTest {
 
-    Product toothbrush = new Product("toothbrush", ProductUnit.Each);
-    Product apples = new Product("apples", ProductUnit.Kilo);
+    Product toothbrush = new Product("toothbrush", ProductUnit.EACH);
+    Product apples = new Product("apples", ProductUnit.KILO);
     Receipt receipt = new Receipt();
 
     @Test

--- a/java/src/test/java/dojo/supermarket/model/SupermarketTest.java
+++ b/java/src/test/java/dojo/supermarket/model/SupermarketTest.java
@@ -10,10 +10,10 @@ class SupermarketTest {
     private final SupermarketCatalog catalog = new FakeCatalog();
     private final Teller teller = new Teller(catalog);
     private final ShoppingCart theCart = new ShoppingCart();
-    private final Product toothbrush = new Product("toothbrush", ProductUnit.Each);
-    private final Product rice = new Product("rice", ProductUnit.Each);
-    private final Product apples = new Product("apples", ProductUnit.Kilo);
-    private final Product cherryTomatoes = new Product("cherry tomato box", ProductUnit.Each);
+    private final Product toothbrush = new Product("toothbrush", ProductUnit.EACH);
+    private final Product rice = new Product("rice", ProductUnit.EACH);
+    private final Product apples = new Product("apples", ProductUnit.KILO);
+    private final Product cherryTomatoes = new Product("cherry tomato box", ProductUnit.EACH);
 
     @BeforeEach
     void setUp() {

--- a/java/src/test/java/dojo/supermarket/model/SupermarketTest.java
+++ b/java/src/test/java/dojo/supermarket/model/SupermarketTest.java
@@ -5,7 +5,8 @@ import org.approvaltests.Approvals;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class SupermarketTest {
+class SupermarketTest {
+
     private SupermarketCatalog catalog = new FakeCatalog();
     private Teller teller = new Teller(catalog);
     private ShoppingCart theCart = new ShoppingCart();
@@ -15,7 +16,7 @@ public class SupermarketTest {
     private Product cherryTomatoes = new Product("cherry tomato box", ProductUnit.Each);
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         catalog.addProduct(toothbrush, 0.99);
         catalog.addProduct(rice, 2.99);
         catalog.addProduct(apples, 1.99);
@@ -23,20 +24,20 @@ public class SupermarketTest {
     }
 
     @Test
-    public void an_empty_shopping_cart_should_cost_nothing() {
+    void an_empty_shopping_cart_should_cost_nothing() {
         Receipt receipt = teller.checksOutArticlesFrom(theCart);
         Approvals.verify(new ReceiptPrinter(40).printReceipt(receipt));
     }
 
     @Test
-    public void one_normal_item() {
+    void one_normal_item() {
         theCart.addItem(toothbrush);
         Receipt receipt = teller.checksOutArticlesFrom(theCart);
         Approvals.verify(new ReceiptPrinter(40).printReceipt(receipt));
     }
 
     @Test
-    public void two_normal_items() {
+    void two_normal_items() {
         theCart.addItem(toothbrush);
         theCart.addItem(rice);
         Receipt receipt = teller.checksOutArticlesFrom(theCart);
@@ -44,7 +45,7 @@ public class SupermarketTest {
     }
 
     @Test
-    public void buy_two_get_one_free() {
+    void buy_two_get_one_free() {
         theCart.addItem(toothbrush);
         theCart.addItem(toothbrush);
         theCart.addItem(toothbrush);
@@ -54,14 +55,14 @@ public class SupermarketTest {
     }
 
     @Test
-    public void buy_two_get_one_free_but_insufficient_in_basket() {
+    void buy_two_get_one_free_but_insufficient_in_basket() {
         theCart.addItem(toothbrush);
         teller.addSpecialOffer(SpecialOfferType.ThreeForTwo, toothbrush, catalog.getUnitPrice(toothbrush));
         Receipt receipt = teller.checksOutArticlesFrom(theCart);
         Approvals.verify(new ReceiptPrinter(40).printReceipt(receipt));
     }
     @Test
-    public void buy_five_get_one_free() {
+    void buy_five_get_one_free() {
         theCart.addItem(toothbrush);
         theCart.addItem(toothbrush);
         theCart.addItem(toothbrush);
@@ -73,14 +74,14 @@ public class SupermarketTest {
     }
 
     @Test
-    public void loose_weight_product() {
+    void loose_weight_product() {
         theCart.addItemQuantity(apples, .5);
         Receipt receipt = teller.checksOutArticlesFrom(theCart);
         Approvals.verify(new ReceiptPrinter(40).printReceipt(receipt));
     }
 
     @Test
-    public void percent_discount() {
+    void percent_discount() {
         theCart.addItem(rice);
         teller.addSpecialOffer(SpecialOfferType.TenPercentDiscount, rice, 10.0);
         Receipt receipt = teller.checksOutArticlesFrom(theCart);
@@ -88,7 +89,7 @@ public class SupermarketTest {
     }
 
     @Test
-    public void xForY_discount() {
+    void xForY_discount() {
         theCart.addItem(cherryTomatoes);
         theCart.addItem(cherryTomatoes);
         teller.addSpecialOffer(SpecialOfferType.TwoForAmount, cherryTomatoes,.99);
@@ -97,7 +98,7 @@ public class SupermarketTest {
     }
 
     @Test
-    public void xForY_discount_with_insufficient_in_basket() {
+    void xForY_discount_with_insufficient_in_basket() {
         theCart.addItem(cherryTomatoes);
         teller.addSpecialOffer(SpecialOfferType.TwoForAmount, cherryTomatoes,.99);
         Receipt receipt = teller.checksOutArticlesFrom(theCart);
@@ -105,7 +106,7 @@ public class SupermarketTest {
     }
 
     @Test
-    public void FiveForY_discount() {
+    void FiveForY_discount() {
         theCart.addItemQuantity(apples, 5);
         teller.addSpecialOffer(SpecialOfferType.FiveForAmount, apples,6.99);
         Receipt receipt = teller.checksOutArticlesFrom(theCart);
@@ -113,7 +114,7 @@ public class SupermarketTest {
     }
 
     @Test
-    public void FiveForY_discount_withSix() {
+    void FiveForY_discount_withSix() {
         theCart.addItemQuantity(apples, 6);
         teller.addSpecialOffer(SpecialOfferType.FiveForAmount, apples,5.99);
         Receipt receipt = teller.checksOutArticlesFrom(theCart);
@@ -121,7 +122,7 @@ public class SupermarketTest {
     }
 
     @Test
-    public void FiveForY_discount_withSixteen() {
+    void FiveForY_discount_withSixteen() {
         theCart.addItemQuantity(apples, 16);
         teller.addSpecialOffer(SpecialOfferType.FiveForAmount, apples,7.99);
         Receipt receipt = teller.checksOutArticlesFrom(theCart);
@@ -129,10 +130,11 @@ public class SupermarketTest {
     }
 
     @Test
-    public void FiveForY_discount_withFour() {
+    void FiveForY_discount_withFour() {
         theCart.addItemQuantity(apples, 4);
         teller.addSpecialOffer(SpecialOfferType.FiveForAmount, apples,8.99);
         Receipt receipt = teller.checksOutArticlesFrom(theCart);
         Approvals.verify(new ReceiptPrinter(40).printReceipt(receipt));
     }
+
 }

--- a/java/src/test/java/dojo/supermarket/model/SupermarketTest.java
+++ b/java/src/test/java/dojo/supermarket/model/SupermarketTest.java
@@ -6,29 +6,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class SupermarketTest {
-    private SupermarketCatalog catalog;
-    private Teller teller;
-    private ShoppingCart theCart;
-    private Product toothbrush;
-    private Product rice;
-    private Product apples;
-    private Product cherryTomatoes;
+    private SupermarketCatalog catalog = new FakeCatalog();
+    private Teller teller = new Teller(catalog);
+    private ShoppingCart theCart = new ShoppingCart();
+    private Product toothbrush = new Product("toothbrush", ProductUnit.Each);
+    private Product rice = new Product("rice", ProductUnit.Each);
+    private Product apples = new Product("apples", ProductUnit.Kilo);
+    private Product cherryTomatoes = new Product("cherry tomato box", ProductUnit.Each);
 
     @BeforeEach
     public void setUp() {
-        catalog = new FakeCatalog();
-        teller = new Teller(catalog);
-        theCart = new ShoppingCart();
-
-        toothbrush = new Product("toothbrush", ProductUnit.Each);
         catalog.addProduct(toothbrush, 0.99);
-        rice = new Product("rice", ProductUnit.Each);
         catalog.addProduct(rice, 2.99);
-        apples = new Product("apples", ProductUnit.Kilo);
         catalog.addProduct(apples, 1.99);
-        cherryTomatoes = new Product("cherry tomato box", ProductUnit.Each);
         catalog.addProduct(cherryTomatoes, 0.69);
-
     }
 
     @Test

--- a/java/src/test/java/dojo/supermarket/model/SupermarketTest.java
+++ b/java/src/test/java/dojo/supermarket/model/SupermarketTest.java
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.Test;
 
 class SupermarketTest {
 
-    private SupermarketCatalog catalog = new FakeCatalog();
-    private Teller teller = new Teller(catalog);
-    private ShoppingCart theCart = new ShoppingCart();
-    private Product toothbrush = new Product("toothbrush", ProductUnit.Each);
-    private Product rice = new Product("rice", ProductUnit.Each);
-    private Product apples = new Product("apples", ProductUnit.Kilo);
-    private Product cherryTomatoes = new Product("cherry tomato box", ProductUnit.Each);
+    private final SupermarketCatalog catalog = new FakeCatalog();
+    private final Teller teller = new Teller(catalog);
+    private final ShoppingCart theCart = new ShoppingCart();
+    private final Product toothbrush = new Product("toothbrush", ProductUnit.Each);
+    private final Product rice = new Product("rice", ProductUnit.Each);
+    private final Product apples = new Product("apples", ProductUnit.Kilo);
+    private final Product cherryTomatoes = new Product("cherry tomato box", ProductUnit.Each);
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
There is no need to create the instances inside the `setUp` method. 

In our coaching sessions, we often observe that it is not widely known that JUnit creates member variables anew for each test. As a result, there are often `@BeforeEach`-annotated methods that are not necessary. This is another argument for the refactoring, as initialization can be done directly at the declaration. 

Another minor change (second commit cb06ed634b9924cda17e47adbf96753f2713a365) is the remove of `pulblic` modifiers which are not necessary with JUnit5 or newer. 

On a related note, I personally prefer leaving field members without access modifiers in JUnit 5 tests (i.e., no `private`). However, this is just my personal style, and I understand that some IDEs or tools might flag this and suggest making the members `private`. For this reason, I decided not to propose this change.

What do you think about this change(s)? I wanted to discuss it first because I would have to make an additional PR for each further branch. Alternatively, a maintainer could do cherry-picking to avoid those PRs.